### PR TITLE
Support single quote imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ if (!fs.existsSync(moduleRootAbsolute)) {
   throw new Error('Directory "' + moduleRootAbsolute + '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript');
 }
 
-const importRegEx = /import\("([^"]*)"\)\.([^ \.\|\}><,\)=\n]*)([ \.\|\}><,\)=\n])/g;
+const importRegEx = /import\(["']([^"']*)["']\)\.([^ \.\|\}><,\)=\n]*)([ \.\|\}><,\)=\n])/g;
 const typedefRegEx = /@typedef \{[^\}]*\} ([^ \r?\n?]*)/;
 const noClassdescRegEx = /@(typedef|module|type)/;
 


### PR DESCRIPTION
This pull request adds support for single quotes in imports, e.g. `import('ol/PluggableMap').default`.