### PR TITLE
Use exported resolveBorrows function

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const env = require('jsdoc/env');
 const addInherited = require('jsdoc/augment').addInherited;
-const indexAll = require('jsdoc/borrow').indexAll;
+const resolveBorrows = require('jsdoc/borrow').resolveBorrows;
 
 const config = env.conf.typescript;
 if (!config) {
@@ -223,6 +223,6 @@ exports.astNodeVisitor = {
 exports.handlers = {
   parseComplete: function(e) {
     // Build inheritance chain after adding @extends annotations
-    addInherited(e.doclets, indexAll(e.doclets));
+    addInherited(e.doclets, resolveBorrows(e.doclets));
   }
 }


### PR DESCRIPTION
The `borrows` module exports [a `resolveBorrows` function](https://github.com/jsdoc/jsdoc/blob/3.6.0/lib/jsdoc/borrow.js#L45-L52).  It doesn't export an `indexAll` function.

It isn't clear to me how this worked before, but perhaps `requizzle` was somehow involved.  This plugin doesn't work with JSDoc 3.6 because `indexAll` is not a function (it wasn't exported previously, but somehow worked).  See https://circleci.com/gh/openlayers/openlayers/1224 for an example build failure (from https://github.com/openlayers/openlayers/pull/9491)