### PR TITLE
Allow a range of JSDoc versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "BSD-2-Clause",
   "peerDependencies": {
-    "jsdoc": "3.6.0"
+    "jsdoc": ">=3.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This makes it so 3.6 and above are acceptable peer versions.

Without this change, installing the `ol` package results in this:
```
npm WARN jsdoc-plugin-typescript@2.0.0 requires a peer of jsdoc@3.6.0 but none is installed. You must install peer dependencies yourself.
```