### PR TITLE
Type rewrite further improvement

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,6 @@ const fileNodes = {};
 
 function getModuleInfo(moduleId, parser) {
   if (!moduleInfos[moduleId]) {
-    const moduleInfo = moduleInfos[moduleId] = {
-      namedExports: {}
-    };
     if (!fileNodes[moduleId]) {
       const absolutePath = path.join(process.cwd(), moduleRoot, moduleId + '.js');
       if (!fs.existsSync(absolutePath)) {
@@ -37,6 +34,9 @@ function getModuleInfo(moduleId, parser) {
       const file = fs.readFileSync(absolutePath, 'UTF-8');
       fileNodes[moduleId] = parser.astBuilder.build(file, absolutePath);
     }
+    const moduleInfo = moduleInfos[moduleId] = {
+      namedExports: {}
+    };
     const node = fileNodes[moduleId];
     if (node.program && node.program.body) {
       const classDeclarations = {};
@@ -201,10 +201,10 @@ exports.astNodeVisitor = {
         node.comments.forEach(comment => {
           // Replace local types with the full `module:` path
           Object.keys(identifiers).forEach(key => {
-            const eventRegex = new RegExp(`@(event |fires )${key}(\\s*)`, 'g');
+            const eventRegex = new RegExp(`@(event |fires )${key}([^A-Za-z])`, 'g');
             replace(eventRegex);
 
-            const typeRegex = new RegExp(`@(.*[{<|,]\\s*[!?]?)${key}(=?\\s*[}>|,])`, 'g');
+            const typeRegex = new RegExp(`@(.*[{<|,(!?:]\\s*)${key}([A-Za-z].*?\}|\})`, 'g');
             replace(typeRegex);
 
             function replace(regex) {


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/10075

Because regex are inherently bad at matching nested structures and I had fun in digging into grammar and especially pegjs (https://pegjs.org/), I wrote a grammar to perform the type rewrites. I also made a branch (https://github.com/openlayers/jsdoc-plugin-typescript/pull/12), but I don't know if this should be merged because it would introduce a new syntax that might be difficult to maintain if not known and a new dependency. 

The parser approach has 2 big advantages: It can easily handle nested structures and it can throw errors if it finds expressions that it should be able to parse, but some type is missing.

Nevertheless I used this grammar to check the output of our regular expression and found several issues. I created a new regex that does not produce any false positives and only misses a handful of rewrites in the whole code base.

Examples for expressions it can not handle are multiline types and some strangely nested types.
```
  * @typedef {function(!SketchCoordType, SimpleGeometry=):
  *     SimpleGeometry} GeometryFunction
```
```
  * @param {{type: string,
  *     target: (EventTargetLike|undefined),
  *     propagationStopped: (boolean|undefined)}|
  *     BaseEvent|string} event Event object.
```
```
  * @type {!Object<string, (Array<Feature>|Feature|undefined)>} 
```
I also found some more incorrect annotations in the codebase, that I fix in PR on the main repository.