### PR TITLE
Add support for template literal types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Types defined in a project are converted to JSDoc module paths, so they can be d
 
 In addition to types that are used in the same file that they are defined in, imported types are also supported.
 
-TypeScript and JSDoc use a different syntax for imported types:
+TypeScript and JSDoc use a different syntax for imported types. This plugin converts the TypeScript types so JSDoc can handle them:
 
 ### TypeScript
 
@@ -59,6 +59,12 @@ TypeScript and JSDoc use a different syntax for imported types:
  * @type {typeof import("./path/to/module").exportName}
  */
 ```
+
+**Template literal type**
+```js
+/**
+ * @type {`static:${dynamic}`}
+ */
 
 ### JSDoc
 
@@ -91,3 +97,9 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
  * @type {Class<module:path/to/module.exportName>}
  */
 ```
+
+**Template literal type**
+```js
+/**
+ * @type {'static:${dynamic}'}
+ */

--- a/index.js
+++ b/index.js
@@ -190,6 +190,8 @@ exports.astNodeVisitor = {
         node.comments.forEach(comment => {
           // Replace typeof Foo with Class<Foo>
           comment.value = comment.value.replace(/typeof ([^,\|\}\>]*)([,\|\}\>])/g, 'Class<$1>$2');
+          // Replace `templateliteral` with 'templateliteral'
+          comment.value = comment.value.replace(/`([^`]*)`/g, '\'$1\'');
 
           // Convert `import("path/to/module").export` to
           // `module:path/to/module~Name`


### PR DESCRIPTION
This pull request adds support for TypeScript's [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html). On the JSDoc side, it does not do anything special with these types, it just converts them to plain strings by changing backticks to single quotes.