### PR TITLE
Remove @override annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
  * @type {`static:${dynamic}`}
  */
 
+**@override annotations**
+
+are removed because they make JSDoc stop inheritance
+
 ### JSDoc
 
 **Named export:**

--- a/index.js
+++ b/index.js
@@ -298,6 +298,9 @@ exports.astNodeVisitor = {
             'Class<$1>$2'
           );
 
+          // Remove `@override` annotations to avoid JSDoc breaking the inheritance chain
+          comment.value = comment.value.replace(' @override', ' ');
+
           // Convert `import("path/to/module").export` to
           // `module:path/to/module~Name`
           let importMatch, lastImportPath, replaceAttempt;


### PR DESCRIPTION
`@override` annotations required by TypeScript make JSDoc break the inheritance chain of the annotated method. This pull request simply removes these `@override` annotations. JSDoc detects inheritance by itself.