### PR TITLE
Extra TS syntax support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": false
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "bracketSpacing": false
-}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ### TypeScript
 
 **Named export:**
+
 ```js
 /**
  * @type {import("./path/to/module").exportName}
@@ -47,6 +48,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **Default export:**
+
 ```js
 /**
  * @type {import("./path/to/module").default}
@@ -54,6 +56,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **typeof type:**
+
 ```js
 /**
  * @type {typeof import("./path/to/module").exportName}
@@ -61,10 +64,12 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **Template literal type**
+
 ```js
 /**
  * @type {`static:${dynamic}`}
  */
+```
 
 **@override annotations**
 
@@ -73,6 +78,7 @@ are removed because they make JSDoc stop inheritance
 ### JSDoc
 
 **Named export:**
+
 ```js
 /**
  * @type {module:path/to/module.exportName}
@@ -80,6 +86,7 @@ are removed because they make JSDoc stop inheritance
 ```
 
 **Default export assigned to a variable in the exporting module:**
+
 ```js
 /**
  * @type {module:path/to/module~variableOfDefaultExport}
@@ -89,6 +96,7 @@ are removed because they make JSDoc stop inheritance
 This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 
 **Anonymous default export:**
+
 ```js
 /**
  * @type {module:path/to/module}
@@ -96,6 +104,7 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 ```
 
 **typeof type:**
+
 ```js
 /**
  * @type {Class<module:path/to/module.exportName>}
@@ -103,6 +112,7 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 ```
 
 **Template literal type**
+
 ```js
 /**
  * @type {'static:${dynamic}'}

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ In addition to types that are used in the same file that they are defined in, im
 
 TypeScript and JSDoc use a different syntax for imported types. This plugin converts the TypeScript types so JSDoc can handle them:
 
-### TypeScript
-
-**Named export:**
+### Named export
 
 ```js
 /**
@@ -47,37 +45,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
  */
 ```
 
-**Default export:**
-
-```js
-/**
- * @type {import("./path/to/module").default}
- */
-```
-
-**typeof type:**
-
-```js
-/**
- * @type {typeof import("./path/to/module").exportName}
- */
-```
-
-**Template literal type**
-
-```js
-/**
- * @type {`static:${dynamic}`}
- */
-```
-
-**@override annotations**
-
-are removed because they make JSDoc stop inheritance
-
-### JSDoc
-
-**Named export:**
+To:
 
 ```js
 /**
@@ -85,7 +53,23 @@ are removed because they make JSDoc stop inheritance
  */
 ```
 
-**Default export assigned to a variable in the exporting module:**
+### Default export
+
+```js
+/**
+ * @type {import("./path/to/module").default}
+ */
+```
+
+To:
+
+```js
+/**
+ * @type {module:path/to/module}
+ */
+```
+
+When assigned to a variable in the exporting module:
 
 ```js
 /**
@@ -95,15 +79,15 @@ are removed because they make JSDoc stop inheritance
 
 This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 
-**Anonymous default export:**
+### `typeof type`
 
 ```js
 /**
- * @type {module:path/to/module}
+ * @type {typeof import("./path/to/module").exportName}
  */
 ```
 
-**typeof type:**
+To:
 
 ```js
 /**
@@ -111,11 +95,73 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
  */
 ```
 
-**Template literal type**
+### Template literal type
+
+```js
+/**
+ * @type {`static:${dynamic}`}
+ */
+```
+
+To:
 
 ```js
 /**
  * @type {'static:${dynamic}'}
+ */
+```
+
+### @override annotations
+
+are removed because they make JSDoc stop inheritance
+
+### Interface style semi-colon separators
+
+```js
+/**
+ * @type {{a: number; b: string;}}
+ */
+```
+
+To:
+
+```js
+/**
+ * @type {{a: number, b: string}}
+ */
+```
+
+Also removes trailing commas from object types.
+
+### TS inline function syntax
+
+```js
+/**
+ * @type {(a: number, b: string) => void}
+ */
+```
+
+To:
+
+```js
+/**
+ * @type {function(): void}
+ */
+```
+
+### Bracket notation
+
+```js
+/**
+ * @type {obj['key']}
+ */
+```
+
+To:
+
+```js
+/**
+ * @type {obj.key}
  */
 ```
 

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ const addInherited = require('jsdoc/augment').addInherited; // eslint-disable-li
 const config = env.conf.typescript;
 if (!config) {
   throw new Error(
-    'Configuration "typescript" for jsdoc-plugin-typescript missing.',
+    'Configuration "typescript" for jsdoc-plugin-typescript missing.'
   );
 }
 if (!('moduleRoot' in config)) {
   throw new Error(
-    'Configuration "typescript.moduleRoot" for jsdoc-plugin-typescript missing.',
+    'Configuration "typescript.moduleRoot" for jsdoc-plugin-typescript missing.'
   );
 }
 const moduleRoot = config.moduleRoot;
@@ -21,7 +21,7 @@ if (!fs.existsSync(moduleRootAbsolute)) {
   throw new Error(
     'Directory "' +
       moduleRootAbsolute +
-      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript',
+      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript'
   );
 }
 
@@ -47,7 +47,7 @@ function getModuleInfo(moduleId, extension, parser) {
       const absolutePath = path.join(
         process.cwd(),
         moduleRoot,
-        moduleId + extension,
+        moduleId + extension
       );
       if (!fs.existsSync(absolutePath)) {
         return null;
@@ -92,51 +92,72 @@ function getDelimiter(moduleId, symbol, parser) {
 }
 
 exports.defineTags = function (dictionary) {
-  ['type', 'typedef', 'property', 'return', 'param', 'template'].forEach(
-    function (tagName) {
-      const tag = dictionary.lookUp(tagName);
-      const oldOnTagText = tag.onTagText;
-      tag.onTagText = function (tagText) {
-        if (oldOnTagText) {
-          tagText = oldOnTagText.apply(this, arguments);
+  const tags = [
+    'type',
+    'typedef',
+    'property',
+    'return',
+    'param',
+    'template',
+    'default',
+    'member',
+  ];
+
+  tags.forEach(function (tagName) {
+    const tag = dictionary.lookUp(tagName);
+    const oldOnTagText = tag.onTagText;
+    tag.onTagText = function (tagText) {
+      if (oldOnTagText) {
+        tagText = oldOnTagText.apply(this, arguments);
+      }
+
+      const startIndex = tagText.search('{');
+      if (startIndex === -1) {
+        return tagText;
+      }
+      const len = tagText.length;
+      let open = 0;
+      let i = startIndex;
+      while (i < len) {
+        switch (tagText[i]) {
+          case '\\':
+            // Skip escaped character
+            ++i;
+            break;
+          case '{':
+            ++open;
+            break;
+          case '}':
+            if (!--open) {
+              return (
+                tagText.slice(0, startIndex) +
+                tagText
+                  .slice(startIndex, i + 1)
+                  // Replace `templateliteral` with 'templateliteral'
+                  .replace(/`([^`]*)`/g, "'$1'")
+                  // Interface style semi-colon separators to commas
+                  .replace(/;/g, ',')
+                  // Remove trailing commas in object types
+                  .replace(/,(\s*\})/g, '$1')
+                  // TS-style param typing isn't supported, so just strip spaces after all colons
+                  .replace(/:\s*/g, ':')
+                  // Bracket notation to dot notation
+                  .replace(
+                    /(\w+|>|\)|\])\[(?:'([^']+)'|"([^"]+)")\]/g,
+                    '$1.$2$3'
+                  ) +
+                tagText.slice(i + 1)
+              );
+            }
+            break;
+          default:
+            break;
         }
-        // Replace `templateliteral` with 'templateliteral'
-        const startIndex = tagText.search('{');
-        if (startIndex === -1) {
-          return tagText;
-        }
-        const len = tagText.length;
-        let open = 0;
-        let i = startIndex;
-        while (i < len) {
-          switch (tagText[i]) {
-            case '\\':
-              // Skip escaped character
-              ++i;
-              break;
-            case '{':
-              ++open;
-              break;
-            case '}':
-              if (!--open) {
-                return (
-                  tagText.slice(0, startIndex) +
-                  tagText
-                    .slice(startIndex, i + 1)
-                    .replace(/`([^`]*)`/g, "'$1'") +
-                  tagText.slice(i + 1)
-                );
-              }
-              break;
-            default:
-              break;
-          }
-          ++i;
-        }
-        throw new Error("Missing closing '}'");
-      };
-    },
-  );
+        ++i;
+      }
+      throw new Error("Missing closing '}'");
+    };
+  });
 };
 
 exports.astNodeVisitor = {
@@ -229,10 +250,10 @@ exports.astNodeVisitor = {
             if (
               leadingComments.length === 0 ||
               (leadingComments[leadingComments.length - 1].value.indexOf(
-                '@classdesc',
+                '@classdesc'
               ) === -1 &&
                 noClassdescRegEx.test(
-                  leadingComments[leadingComments.length - 1].value,
+                  leadingComments[leadingComments.length - 1].value
                 ))
             ) {
               // Create a suitable comment node if we don't have one on the class yet
@@ -250,7 +271,7 @@ exports.astNodeVisitor = {
             if (node.superClass) {
               // Remove the `@extends` tag because JSDoc does not does not handle generic type. (`@extends {Base<Type>}`)
               const extendsIndex = lines.findIndex((line) =>
-                line.includes('@extends'),
+                line.includes('@extends')
               );
               if (extendsIndex !== -1) {
                 lines.splice(extendsIndex, 1);
@@ -262,7 +283,7 @@ exports.astNodeVisitor = {
               if (identifier) {
                 const absolutePath = path.resolve(
                   path.dirname(currentSourceName),
-                  identifier.value,
+                  identifier.value
                 );
                 // default to js extension since .js extention is assumed implicitly
                 const extension = getExtension(absolutePath);
@@ -295,7 +316,7 @@ exports.astNodeVisitor = {
           // Replace typeof Foo with Class<Foo>
           comment.value = comment.value.replace(
             /typeof ([^,\|\}\>]*)([,\|\}\>])/g,
-            'Class<$1>$2',
+            'Class<$1>$2'
           );
 
           // Remove `@override` annotations to avoid JSDoc breaking the inheritance chain
@@ -323,7 +344,7 @@ exports.astNodeVisitor = {
                 if (replaceAttempt > 100) {
                   // infinite loop protection
                   throw new Error(
-                    `Invalid docstring ${comment.value} in ${currentSourceName}.`,
+                    `Invalid docstring ${comment.value} in ${currentSourceName}.`
                   );
                 }
               } else {
@@ -332,7 +353,7 @@ exports.astNodeVisitor = {
               lastImportPath = importExpression;
               const rel = path.resolve(
                 path.dirname(currentSourceName),
-                importSource,
+                importSource
               );
               // default to js extension since .js extention is assumed implicitly
               const extension = getExtension(rel);
@@ -356,7 +377,7 @@ exports.astNodeVisitor = {
             if (replacement) {
               comment.value = comment.value.replace(
                 importExpression,
-                replacement + remainder,
+                replacement + remainder
               );
             }
           }
@@ -377,13 +398,13 @@ exports.astNodeVisitor = {
           Object.keys(identifiers).forEach((key) => {
             const eventRegex = new RegExp(
               `@(event |fires )${key}([^A-Za-z])`,
-              'g',
+              'g'
             );
             replace(eventRegex);
 
             const typeRegex = new RegExp(
               `@(.*[{<|,(!?:]\\s*)${key}([^A-Za-z].*?\}|\})`,
-              'g',
+              'g'
             );
             replace(typeRegex);
 
@@ -392,7 +413,7 @@ exports.astNodeVisitor = {
                 const identifier = identifiers[key];
                 const absolutePath = path.resolve(
                   path.dirname(currentSourceName),
-                  identifier.value,
+                  identifier.value
                 );
                 // default to js extension since .js extention is assumed implicitly
                 const extension = getExtension(absolutePath);
@@ -408,11 +429,11 @@ exports.astNodeVisitor = {
                     : getDelimiter(moduleId, exportName, parser);
                   const replacement = `module:${moduleId.replace(
                     slashRegEx,
-                    '/',
+                    '/'
                   )}${exportName ? delimiter + exportName : ''}`;
                   comment.value = comment.value.replace(
                     regex,
-                    '@$1' + replacement + '$2',
+                    '@$1' + replacement + '$2'
                   );
                 }
               }

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ exports.defineTags = function (dictionary) {
 
               // Replace TS inline function syntax with JSDoc
               functionIndices.reverse().forEach(([start, end]) => {
-                if (tagText.slice(0, start).endsWith('function')) {
+                if (tagText.slice(0, start).trim().endsWith('function')) {
                   // Already JSDoc syntax
                   return;
                 }

--- a/index.js
+++ b/index.js
@@ -91,6 +91,31 @@ function getDelimiter(moduleId, symbol, parser) {
   return getModuleInfo(moduleId, parser).namedExports[symbol] ? '.' : '~';
 }
 
+/**
+ * Replaces text by indices where each element of `replacements` is `[startIndex, endIndex, replacement]`.
+ *
+ * Note: This function does not handle nested replacements.
+ *
+ * @param {string} text The text to replace
+ * @param {Array<[number, number, string]>} replacements The replacements to apply
+ * @return {string} The text with replacements applied
+ */
+function replaceByIndices(text, replacements) {
+  let offset = 0;
+  let replacedText = text;
+
+  replacements.forEach(([startIndex, endIndex, replacement], i) => {
+    const head = replacedText.slice(0, startIndex + offset);
+    const tail = replacedText.slice(endIndex + offset);
+
+    replacedText = head + replacement + tail;
+
+    offset += replacement.length - (endIndex - startIndex);
+  });
+
+  return replacedText;
+}
+
 exports.defineTags = function (dictionary) {
   const tags = [
     'type',
@@ -107,6 +132,10 @@ exports.defineTags = function (dictionary) {
     const tag = dictionary.lookUp(tagName);
     const oldOnTagText = tag.onTagText;
 
+    /**
+     * @param {string} tagText The tag text
+     * @return {string} The modified tag text
+     */
     tag.onTagText = function (tagText) {
       if (oldOnTagText) {
         tagText = oldOnTagText.apply(this, arguments);
@@ -118,12 +147,15 @@ exports.defineTags = function (dictionary) {
       }
 
       const len = tagText.length;
-      const functionIndices = [];
 
+      /** @type {Array<[number, number, string]>} */
+      let replacements = [];
       let openCurly = 0;
       let openRound = 0;
+      let isWithinString = false;
+      let quoteChar = '';
       let i = startIndex;
-      let functionStartEnd = [];
+      let functionStartIndex;
 
       while (i < len) {
         switch (tagText[i]) {
@@ -131,9 +163,29 @@ exports.defineTags = function (dictionary) {
             // Skip escaped character
             ++i;
             break;
+          case '"':
+          case "'":
+            if (isWithinString && quoteChar === tagText[i]) {
+              isWithinString = false;
+              quoteChar = '';
+            } else if (!isWithinString) {
+              isWithinString = true;
+              quoteChar = tagText[i];
+            }
+
+            break;
+          case ';':
+            // Replace interface-style semi-colon separators with commas
+            if (!isWithinString && openCurly > 1) {
+              const isTrailingSemiColon = /^\s*}/.test(tagText.slice(i + 1));
+
+              replacements.push([i, i + 1, isTrailingSemiColon ? '' : ',']);
+            }
+
+            break;
           case '(':
             if (openRound === 0) {
-              functionStartEnd.push(i);
+              functionStartIndex = i;
             }
 
             ++openRound;
@@ -144,12 +196,26 @@ exports.defineTags = function (dictionary) {
               // If round brackets form a function
               const returnMatch = tagText.slice(i + 1).match(/^\s*(:|=>)/);
 
+              // Replace TS inline function syntax with JSDoc
               if (returnMatch) {
-                functionStartEnd.push(i + returnMatch[0].length + 1);
-                functionIndices.push(functionStartEnd);
+                const functionEndIndex = i + returnMatch[0].length + 1;
+                const hasFunctionKeyword = /\bfunction\s*$/.test(
+                  tagText.slice(0, functionStartIndex),
+                );
+
+                // Filter out any replacements that are within the function
+                replacements = replacements.filter(([startIndex]) => {
+                  return startIndex < functionStartIndex || startIndex > i;
+                });
+
+                replacements.push([
+                  functionStartIndex,
+                  functionEndIndex,
+                  hasFunctionKeyword ? '():' : 'function():',
+                ]);
               }
 
-              functionStartEnd = [];
+              functionStartIndex = null;
             }
 
             break;
@@ -161,28 +227,12 @@ exports.defineTags = function (dictionary) {
               const head = tagText.slice(0, startIndex);
               const tail = tagText.slice(i + 1);
 
-              let replaced = tagText.slice(startIndex, i + 1);
-
-              // Replace TS inline function syntax with JSDoc
-              functionIndices.reverse().forEach(([start, end]) => {
-                if (tagText.slice(0, start).trim().endsWith('function')) {
-                  // Already JSDoc syntax
-                  return;
-                }
-
-                replaced =
-                  replaced.slice(0, start - startIndex) +
-                  'function():' +
-                  replaced.slice(end - startIndex);
-              });
-
-              replaced = replaced
+              const replaced = replaceByIndices(
+                tagText.slice(startIndex, i + 1),
+                replacements,
+              )
                 // Replace `templateliteral` with 'templateliteral'
                 .replace(/`([^`]*)`/g, "'$1'")
-                // Interface style semi-colon separators to commas
-                .replace(/;/g, ',')
-                // Remove trailing commas in object types
-                .replace(/,(\s*\})/g, '$1')
                 // Bracket notation to dot notation
                 .replace(
                   /(\w+|>|\)|\])\[(?:'([^']+)'|"([^"]+)")\]/g,

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ const addInherited = require('jsdoc/augment').addInherited; // eslint-disable-li
 const config = env.conf.typescript;
 if (!config) {
   throw new Error(
-    'Configuration "typescript" for jsdoc-plugin-typescript missing.'
+    'Configuration "typescript" for jsdoc-plugin-typescript missing.',
   );
 }
 if (!('moduleRoot' in config)) {
   throw new Error(
-    'Configuration "typescript.moduleRoot" for jsdoc-plugin-typescript missing.'
+    'Configuration "typescript.moduleRoot" for jsdoc-plugin-typescript missing.',
   );
 }
 const moduleRoot = config.moduleRoot;
@@ -21,7 +21,7 @@ if (!fs.existsSync(moduleRootAbsolute)) {
   throw new Error(
     'Directory "' +
       moduleRootAbsolute +
-      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript'
+      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript',
   );
 }
 
@@ -47,7 +47,7 @@ function getModuleInfo(moduleId, extension, parser) {
       const absolutePath = path.join(
         process.cwd(),
         moduleRoot,
-        moduleId + extension
+        moduleId + extension,
       );
       if (!fs.existsSync(absolutePath)) {
         return null;
@@ -186,7 +186,7 @@ exports.defineTags = function (dictionary) {
                 // Bracket notation to dot notation
                 .replace(
                   /(\w+|>|\)|\])\[(?:'([^']+)'|"([^"]+)")\]/g,
-                  '$1.$2$3'
+                  '$1.$2$3',
                 );
 
               return head + replaced + tail;
@@ -293,10 +293,10 @@ exports.astNodeVisitor = {
             if (
               leadingComments.length === 0 ||
               (leadingComments[leadingComments.length - 1].value.indexOf(
-                '@classdesc'
+                '@classdesc',
               ) === -1 &&
                 noClassdescRegEx.test(
-                  leadingComments[leadingComments.length - 1].value
+                  leadingComments[leadingComments.length - 1].value,
                 ))
             ) {
               // Create a suitable comment node if we don't have one on the class yet
@@ -314,7 +314,7 @@ exports.astNodeVisitor = {
             if (node.superClass) {
               // Remove the `@extends` tag because JSDoc does not does not handle generic type. (`@extends {Base<Type>}`)
               const extendsIndex = lines.findIndex((line) =>
-                line.includes('@extends')
+                line.includes('@extends'),
               );
               if (extendsIndex !== -1) {
                 lines.splice(extendsIndex, 1);
@@ -326,7 +326,7 @@ exports.astNodeVisitor = {
               if (identifier) {
                 const absolutePath = path.resolve(
                   path.dirname(currentSourceName),
-                  identifier.value
+                  identifier.value,
                 );
                 // default to js extension since .js extention is assumed implicitly
                 const extension = getExtension(absolutePath);
@@ -359,7 +359,7 @@ exports.astNodeVisitor = {
           // Replace typeof Foo with Class<Foo>
           comment.value = comment.value.replace(
             /typeof ([^,\|\}\>]*)([,\|\}\>])/g,
-            'Class<$1>$2'
+            'Class<$1>$2',
           );
 
           // Remove `@override` annotations to avoid JSDoc breaking the inheritance chain
@@ -387,7 +387,7 @@ exports.astNodeVisitor = {
                 if (replaceAttempt > 100) {
                   // infinite loop protection
                   throw new Error(
-                    `Invalid docstring ${comment.value} in ${currentSourceName}.`
+                    `Invalid docstring ${comment.value} in ${currentSourceName}.`,
                   );
                 }
               } else {
@@ -396,7 +396,7 @@ exports.astNodeVisitor = {
               lastImportPath = importExpression;
               const rel = path.resolve(
                 path.dirname(currentSourceName),
-                importSource
+                importSource,
               );
               // default to js extension since .js extention is assumed implicitly
               const extension = getExtension(rel);
@@ -420,7 +420,7 @@ exports.astNodeVisitor = {
             if (replacement) {
               comment.value = comment.value.replace(
                 importExpression,
-                replacement + remainder
+                replacement + remainder,
               );
             }
           }
@@ -441,13 +441,13 @@ exports.astNodeVisitor = {
           Object.keys(identifiers).forEach((key) => {
             const eventRegex = new RegExp(
               `@(event |fires )${key}([^A-Za-z])`,
-              'g'
+              'g',
             );
             replace(eventRegex);
 
             const typeRegex = new RegExp(
               `@(.*[{<|,(!?:]\\s*)${key}([^A-Za-z].*?\}|\})`,
-              'g'
+              'g',
             );
             replace(typeRegex);
 
@@ -456,7 +456,7 @@ exports.astNodeVisitor = {
                 const identifier = identifiers[key];
                 const absolutePath = path.resolve(
                   path.dirname(currentSourceName),
-                  identifier.value
+                  identifier.value,
                 );
                 // default to js extension since .js extention is assumed implicitly
                 const extension = getExtension(absolutePath);
@@ -472,11 +472,11 @@ exports.astNodeVisitor = {
                     : getDelimiter(moduleId, exportName, parser);
                   const replacement = `module:${moduleId.replace(
                     slashRegEx,
-                    '/'
+                    '/',
                   )}${exportName ? delimiter + exportName : ''}`;
                   comment.value = comment.value.replace(
                     regex,
-                    '@$1' + replacement + '$2'
+                    '@$1' + replacement + '$2',
                   );
                 }
               }

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -238,11 +238,11 @@
     "memberof": "module:test"
   },
   {
-    "comment": "/**\n * @type {{a: number; b: string;}}\n */",
+    "comment": "/**\n * @type {{a: number; b: string;c:{a:number},d: {a:number;b:string,c:number }; e: \"{a: number; b: string;}\"; }}\n */",
     "meta": {
       "range": [
-        618,
-        675
+        695,
+        752
       ],
       "filename": "index.js",
       "lineno": 33,
@@ -267,8 +267,8 @@
     "comment": "",
     "meta": {
       "range": [
-        631,
-        674
+        708,
+        751
       ],
       "filename": "index.js",
       "lineno": 33,
@@ -291,8 +291,8 @@
     "comment": "",
     "meta": {
       "range": [
-        657,
-        661
+        734,
+        738
       ],
       "filename": "index.js",
       "lineno": 34,
@@ -314,8 +314,8 @@
     "comment": "",
     "meta": {
       "range": [
-        665,
-        671
+        742,
+        748
       ],
       "filename": "index.js",
       "lineno": 35,
@@ -337,8 +337,8 @@
     "comment": "/**\n * @type {(...args: Parameters<Class<getNumberStore>>) => void}\n */",
     "meta": {
       "range": [
-        749,
-        797
+        826,
+        874
       ],
       "filename": "index.js",
       "lineno": 41,
@@ -363,8 +363,8 @@
     "comment": "",
     "meta": {
       "range": [
-        762,
-        796
+        839,
+        873
       ],
       "filename": "index.js",
       "lineno": 41,
@@ -383,11 +383,11 @@
     "params": []
   },
   {
-    "comment": "/**\n * @type {(a: () => void | () => void) => void}\n */",
+    "comment": "/**\n * @type {(a: () => void | (a: {a: string; b: number;}) => void) => void}\n */",
     "meta": {
       "range": [
-        855,
-        909
+        958,
+        1012
       ],
       "filename": "index.js",
       "lineno": 46,
@@ -412,8 +412,8 @@
     "comment": "",
     "meta": {
       "range": [
-        868,
-        908
+        971,
+        1011
       ],
       "filename": "index.js",
       "lineno": 46,
@@ -435,8 +435,8 @@
     "comment": "/**\n * @type {function(number): void}\n */",
     "meta": {
       "range": [
-        953,
-        1004
+        1056,
+        1107
       ],
       "filename": "index.js",
       "lineno": 51,
@@ -461,8 +461,8 @@
     "comment": "",
     "meta": {
       "range": [
-        966,
-        1003
+        1069,
+        1106
       ],
       "filename": "index.js",
       "lineno": 51,
@@ -484,8 +484,8 @@
     "comment": "/**\n * @type {interfaceSeparators['a']}\n */",
     "meta": {
       "range": [
-        1050,
-        1083
+        1153,
+        1186
       ],
       "filename": "index.js",
       "lineno": 56,
@@ -510,8 +510,8 @@
     "comment": "",
     "meta": {
       "range": [
-        1063,
-        1082
+        1166,
+        1185
       ],
       "filename": "index.js",
       "lineno": 56,

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -238,6 +238,299 @@
     "memberof": "module:test"
   },
   {
+    "comment": "/**\n * @type {{a: number; b: string;}}\n */",
+    "meta": {
+      "range": [
+        618,
+        675
+      ],
+      "filename": "index.js",
+      "lineno": 33,
+      "columnno": 0,
+      "code": {
+        "name": "exports.interfaceSeparators",
+        "type": "VariableDeclaration"
+      }
+    },
+    "type": {
+      "names": [
+        "Object"
+      ]
+    },
+    "name": "interfaceSeparators",
+    "longname": "module:test.interfaceSeparators",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        631,
+        674
+      ],
+      "filename": "index.js",
+      "lineno": 33,
+      "columnno": 13,
+      "code": {
+        "name": "interfaceSeparators",
+        "type": "ObjectExpression",
+        "value": "{\"a\":1,\"b\":\"2\"}"
+      }
+    },
+    "undocumented": true,
+    "name": "interfaceSeparators",
+    "longname": "module:test~interfaceSeparators",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        657,
+        661
+      ],
+      "filename": "index.js",
+      "lineno": 34,
+      "columnno": 2,
+      "code": {
+        "name": "a",
+        "type": "Literal",
+        "value": 1
+      }
+    },
+    "undocumented": true,
+    "name": "a",
+    "longname": "module:test~interfaceSeparators.a",
+    "kind": "member",
+    "memberof": "module:test~interfaceSeparators",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        665,
+        671
+      ],
+      "filename": "index.js",
+      "lineno": 35,
+      "columnno": 2,
+      "code": {
+        "name": "b",
+        "type": "Literal",
+        "value": "2"
+      }
+    },
+    "undocumented": true,
+    "name": "b",
+    "longname": "module:test~interfaceSeparators.b",
+    "kind": "member",
+    "memberof": "module:test~interfaceSeparators",
+    "scope": "static"
+  },
+  {
+    "comment": "/**\n * @type {(...args: Parameters<Class<getNumberStore>>) => void}\n */",
+    "meta": {
+      "range": [
+        749,
+        797
+      ],
+      "filename": "index.js",
+      "lineno": 41,
+      "columnno": 0,
+      "code": {
+        "name": "exports.tsFunctionSyntax",
+        "type": "VariableDeclaration"
+      }
+    },
+    "type": {
+      "names": [
+        "function"
+      ]
+    },
+    "name": "tsFunctionSyntax",
+    "longname": "module:test.tsFunctionSyntax",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        762,
+        796
+      ],
+      "filename": "index.js",
+      "lineno": 41,
+      "columnno": 13,
+      "code": {
+        "name": "tsFunctionSyntax",
+        "type": "ArrowFunctionExpression"
+      }
+    },
+    "undocumented": true,
+    "name": "tsFunctionSyntax",
+    "longname": "module:test~tsFunctionSyntax",
+    "kind": "function",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "/**\n * @type {(a: () => void | () => void) => void}\n */",
+    "meta": {
+      "range": [
+        855,
+        909
+      ],
+      "filename": "index.js",
+      "lineno": 46,
+      "columnno": 0,
+      "code": {
+        "name": "exports.tsFunctionSyntaxNested",
+        "type": "VariableDeclaration"
+      }
+    },
+    "type": {
+      "names": [
+        "function"
+      ]
+    },
+    "name": "tsFunctionSyntaxNested",
+    "longname": "module:test.tsFunctionSyntaxNested",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        868,
+        908
+      ],
+      "filename": "index.js",
+      "lineno": 46,
+      "columnno": 13,
+      "code": {
+        "name": "tsFunctionSyntaxNested",
+        "type": "ArrowFunctionExpression"
+      }
+    },
+    "undocumented": true,
+    "name": "tsFunctionSyntaxNested",
+    "longname": "module:test~tsFunctionSyntaxNested",
+    "kind": "function",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "/**\n * @type {function(number): void}\n */",
+    "meta": {
+      "range": [
+        953,
+        1004
+      ],
+      "filename": "index.js",
+      "lineno": 51,
+      "columnno": 0,
+      "code": {
+        "name": "exports.jsdocFunctionSyntax",
+        "type": "VariableDeclaration"
+      }
+    },
+    "type": {
+      "names": [
+        "function"
+      ]
+    },
+    "name": "jsdocFunctionSyntax",
+    "longname": "module:test.jsdocFunctionSyntax",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        966,
+        1003
+      ],
+      "filename": "index.js",
+      "lineno": 51,
+      "columnno": 13,
+      "code": {
+        "name": "jsdocFunctionSyntax",
+        "type": "ArrowFunctionExpression"
+      }
+    },
+    "undocumented": true,
+    "name": "jsdocFunctionSyntax",
+    "longname": "module:test~jsdocFunctionSyntax",
+    "kind": "function",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "/**\n * @type {interfaceSeparators['a']}\n */",
+    "meta": {
+      "range": [
+        1050,
+        1083
+      ],
+      "filename": "index.js",
+      "lineno": 56,
+      "columnno": 0,
+      "code": {
+        "name": "exports.bracketNotation",
+        "type": "VariableDeclaration"
+      }
+    },
+    "type": {
+      "names": [
+        "interfaceSeparators.a"
+      ]
+    },
+    "name": "bracketNotation",
+    "longname": "module:test.bracketNotation",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        1063,
+        1082
+      ],
+      "filename": "index.js",
+      "lineno": 56,
+      "columnno": 13,
+      "code": {
+        "name": "bracketNotation",
+        "type": "Literal",
+        "value": 1
+      }
+    },
+    "undocumented": true,
+    "name": "bracketNotation",
+    "longname": "module:test~bracketNotation",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
     "comment": "/**\n * @module test/sub/NumberStore\n */",
     "meta": {
       "filename": "NumberStore.js",

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -26,3 +26,31 @@ export function getBounds(geometry) {
 export function getNumberStore(number) {
   return new NumberStore({number});
 }
+
+/**
+ * @type {{a: number; b: string;}}
+ */
+export const interfaceSeparators = {
+  a: 1,
+  b: '2',
+};
+
+/**
+ * @type {(...args: Parameters<typeof getNumberStore>) => void}
+ */
+export const tsFunctionSyntax = (...args) => {};
+
+/**
+ * @type {(a: () => void | () => void) => void}
+ */
+export const tsFunctionSyntaxNested = (...args) => {};
+
+/**
+ * @type {function(number): void}
+ */
+export const jsdocFunctionSyntax = (...args) => {};
+
+/**
+ * @type {interfaceSeparators['a']}
+ */
+export const bracketNotation = 1;

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -28,7 +28,7 @@ export function getNumberStore(number) {
 }
 
 /**
- * @type {{a: number; b: string;}}
+ * @type {{a: number; b: string;c:{a:number},d: {a:number;b:string,c:number }; e: "{a: number; b: string;}"; }}
  */
 export const interfaceSeparators = {
   a: 1,
@@ -41,7 +41,7 @@ export const interfaceSeparators = {
 export const tsFunctionSyntax = (...args) => {};
 
 /**
- * @type {(a: () => void | () => void) => void}
+ * @type {(a: () => void | (a: {a: string; b: number;}) => void) => void}
  */
 export const tsFunctionSyntaxNested = (...args) => {};
 

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,7 @@ function jsdoc() {
     const child = spawn(
       'npx',
       ['jsdoc', '--configure', 'test/template/config.json'],
-      {cwd: getPath('..')}
+      {cwd: getPath('..'), stdio: [null, 'inherit', null]}
     );
 
     child.stderr.on('data', (data) => {


### PR DESCRIPTION
This PR adds support for:

- Semi-colon separators in object types
- Inline TS function types
- Bracket notation
- `@default` and `@member` tags

Other changes:

- Reformat README, so that in/out examples are in the same sections
- Add `inherit` option for `stdout` in the JSDoc `spawn` call for easier debugging when running tests
- ~Basic Prettier config~

## Additional notes

The semi-colon and trailing comma replacements seem a bit risky, but the only instance I can think of where this could be an issue is in exact string types, e.g. `@type {"a;b"}` would become `@type {"a,b"}`. It's an edge case, but probably good enough reason not to include it. Added it anyway in case you see otherwise.