### PR TITLE
Fix class leading comments order

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ exports.astNodeVisitor = {
                     comment.value.indexOf('@classdesc') !== -1 ||
                     !noClassdescRegEx.test(comment.value)
                   ) {
-                    node.leadingComments.push(comment);
+                    node.leadingComments.unshift(comment);
                     node.parent.leadingComments.splice(i, 1);
                     const ignore =
                       parser.astBuilder.build('/** @ignore */').comments[0];

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -238,6 +238,49 @@
     "memberof": "module:test"
   },
   {
+    "comment": "/** @ignore */",
+    "meta": {
+      "range": [
+        434,
+        465
+      ],
+      "filename": "LeadingComments.js",
+      "lineno": 14,
+      "columnno": 0,
+      "code": {
+        "name": "exports.LeadingComments",
+        "type": "ClassDeclaration"
+      }
+    },
+    "ignore": true,
+    "name": "LeadingComments",
+    "longname": "LeadingComments",
+    "kind": "class",
+    "scope": "global"
+  },
+  {
+    "comment": "/**\n * Doclet\n */",
+    "meta": {
+      "range": [
+        441,
+        465
+      ],
+      "filename": "LeadingComments.js",
+      "lineno": 14,
+      "columnno": 7,
+      "code": {
+        "name": "LeadingComments",
+        "type": "ClassDeclaration",
+        "paramnames": []
+      }
+    },
+    "classdesc": "Doclet",
+    "name": "LeadingComments",
+    "longname": "LeadingComments",
+    "kind": "class",
+    "scope": "global"
+  },
+  {
     "comment": "/**\n * @module test/sub/NumberStore\n */",
     "meta": {
       "filename": "NumberStore.js",

--- a/test/src/sub/LeadingComments.js
+++ b/test/src/sub/LeadingComments.js
@@ -1,0 +1,14 @@
+// Import statement required for JSDoc to include first comment as leading comment of the class.
+// Otherwise, it gets moved in the AST to the `Program` node from the `ExportNamedDeclaration` class node:
+// https://github.com/jsdoc/jsdoc/blob/main/packages/jsdoc-ast/lib/walker.js#L465
+// This itself may be a bug, as it seems to be intended for @module comments.
+import ''; // eslint-disable-line
+
+/*
+  Comment
+*/
+
+/**
+ * Doclet
+ */
+export class LeadingComments {}


### PR DESCRIPTION
Where class leading comments are moved from the export node to the class node, they are looped in reverse order and _pushed_. If an exported class has multiple block comments before it (not just JSDoc comments), their order is reversed and the first comment block is processed as the leading comment instead of the last. 

If the first block comment _isn't_ a JSDoc comment, the class will be excluded from the generated HTML files. If the first block comment _is_ a JSDoc comment, the class will be included in the generated HTML files, but documented with the first comment instead of the last.

[Minimal repro](https://github.com/Daniel-Knights/jsdoc-plugin-typescript-class-leading-comments-bug).