### PR TITLE
Module resolution improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ In the absence of `typescript.moduleRoot`, the plugin will mirror the method JSD
 
 1. Parse the referenced module for an `@module` tag.
 2. If a tag is found and it has an explicit id, use that.
-3. If a tag is found, but it doesn't have an explicit id, use the module's file path relative to the root directory, and remove the file extension.
-
-**NOTE:** The root directory will be `process.cwd()` unless any source files are outside it, in which case, the root folder is considered the nearest shared parent directory of all source files.
+3. If a tag is found, but it doesn't have an explicit id, use the module's file path relative to the nearest shared parent directory, and remove the file extension.
 
 ## What this plugin does
 
@@ -44,6 +42,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ### TypeScript
 
 **Named export:**
+
 ```js
 /**
  * @type {import("./path/to/module").exportName}
@@ -51,6 +50,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **Default export:**
+
 ```js
 /**
  * @type {import("./path/to/module").default}
@@ -58,6 +58,7 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **typeof type:**
+
 ```js
 /**
  * @type {typeof import("./path/to/module").exportName}
@@ -65,10 +66,12 @@ TypeScript and JSDoc use a different syntax for imported types. This plugin conv
 ```
 
 **Template literal type**
+
 ```js
 /**
  * @type {`static:${dynamic}`}
  */
+```
 
 **@override annotations**
 
@@ -77,6 +80,7 @@ are removed because they make JSDoc stop inheritance
 ### JSDoc
 
 **Named export:**
+
 ```js
 /**
  * @type {module:path/to/module.exportName}
@@ -84,6 +88,7 @@ are removed because they make JSDoc stop inheritance
 ```
 
 **Default export assigned to a variable in the exporting module:**
+
 ```js
 /**
  * @type {module:path/to/module~variableOfDefaultExport}
@@ -93,6 +98,7 @@ are removed because they make JSDoc stop inheritance
 This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 
 **Anonymous default export:**
+
 ```js
 /**
  * @type {module:path/to/module}
@@ -100,6 +106,7 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 ```
 
 **typeof type:**
+
 ```js
 /**
  * @type {Class<module:path/to/module.exportName>}
@@ -107,6 +114,7 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 ```
 
 **Template literal type**
+
 ```js
 /**
  * @type {'static:${dynamic}'}

--- a/README.md
+++ b/README.md
@@ -14,20 +14,9 @@ To configure JSDoc to use the plugin, add the following to the JSDoc configurati
 "plugins": [
   "jsdoc-plugin-typescript"
 ],
-"typescript": {
-  "moduleRoot": "src" // optional
-}
 ```
 
 See http://usejsdoc.org/about-configuring-jsdoc.html for more details on how to configure JSDoc.
-
-If `typescript.moduleRoot` is specified, the plugin will assume module ids are relative to that directory and format them as such. For example, `@type {import("./folder/file").Class}` will be converted to `@type {module:folder/file.Class}`. The file extension is removed along with any leading `../` segments (if the referenced module is outside `moduleRoot`).
-
-In the absence of `typescript.moduleRoot`, the plugin will mirror the method JSDoc uses to assign module ids:
-
-1. Parse the referenced module for an `@module` tag.
-2. If a tag is found and it has an explicit id, use that.
-3. If a tag is found, but it doesn't have an explicit id, use the module's file path relative to the nearest shared parent directory, and remove the file extension.
 
 ## What this plugin does
 
@@ -120,6 +109,14 @@ This syntax is also used when referring to types of `@typedef`s and `@enum`s.
  * @type {'static:${dynamic}'}
  */
 ```
+
+## Module id resolution
+
+For resolving module ids, this plugin mirrors the method used by JSDoc:
+
+1. Parse the referenced module for an `@module` tag.
+2. If a tag is found and it has an explicit id, use that.
+3. If a tag is found, but it doesn't have an explicit id, use the module's file path relative to the nearest shared parent directory, and remove the file extension.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,22 +10,24 @@ JSDoc accepts plugins by simply installing their npm package:
 
 To configure JSDoc to use the plugin, add the following to the JSDoc configuration file, e.g. `conf.json`:
 
-```json
+```jsonc
 "plugins": [
   "jsdoc-plugin-typescript"
 ],
 "typescript": {
-  "moduleRoot": "src"
+  "moduleRoot": "src" // optional
 }
 ```
 
 See http://usejsdoc.org/about-configuring-jsdoc.html for more details on how to configure JSDoc.
 
-In the above snippet, `"src"` is the directory that contains the source files. Inside that directory, each `.js` file needs a `@module` annotation with a path relative to that `"moduleRoot"`, e.g.
+If `typescript.moduleRoot` is specified, the plugin will assume module ids are relative to that directory and format them as such. For example, `@type {import("./folder/file").Class}` will be converted to `@type {module:folder/file.Class}`. The file extension is removed along with any leading `../` segments (if the referenced module is outside `moduleRoot`).
 
-```js
-/** @module ol/proj **/
-```
+In the absence of `typescript.moduleRoot`, the plugin will mirror the method JSDoc uses to assign module ids:
+
+1. Parse the referenced module for an `@module` tag.
+2. If a tag is found and it has an explicit id, use that.
+3. If a tag is found, but it doesn't have an explicit id, use the file path relative to the **nearest shared parent directory**, and remove the file extension.
 
 ## What this plugin does
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ In the absence of `typescript.moduleRoot`, the plugin will mirror the method JSD
 
 1. Parse the referenced module for an `@module` tag.
 2. If a tag is found and it has an explicit id, use that.
-3. If a tag is found, but it doesn't have an explicit id, use the file path relative to the **nearest shared parent directory**, and remove the file extension.
+3. If a tag is found, but it doesn't have an explicit id, use the module's file path relative to the root directory, and remove the file extension.
+
+**NOTE:** The root directory will be `process.cwd()` unless any source files are outside it, in which case, the root folder is considered the nearest shared parent directory of all source files.
 
 ## What this plugin does
 

--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ exports.astNodeVisitor = {
                 );
 
                 if (getModuleInfo(absolutePath, parser)) {
-                  const moduleId = moduleInfos[absolutePath];
+                  const moduleId = moduleInfos[absolutePath].id;
 
                   const exportName = identifier.defaultImport
                     ? getDefaultExportName(absolutePath)
@@ -407,7 +407,7 @@ exports.astNodeVisitor = {
               );
 
               if (getModuleInfo(rel, parser)) {
-                const moduleId = moduleInfos[rel];
+                const moduleId = moduleInfos[rel].id;
 
                 const name =
                   exportName === 'default'
@@ -463,7 +463,7 @@ exports.astNodeVisitor = {
                 );
 
                 if (getModuleInfo(absolutePath, parser)) {
-                  const moduleId = moduleInfos[absolutePath];
+                  const moduleId = moduleInfos[absolutePath].id;
 
                   const exportName = identifier.defaultImport
                     ? getDefaultExportName(absolutePath)

--- a/index.js
+++ b/index.js
@@ -4,20 +4,6 @@ const fs = require('fs');
 const env = require('jsdoc/env'); // eslint-disable-line import/no-unresolved
 const addInherited = require('jsdoc/augment').addInherited; // eslint-disable-line import/no-unresolved
 
-const config = env.conf;
-const moduleRoot = config.typescript ? config.typescript.moduleRoot : undefined;
-const moduleRootAbsolute = moduleRoot
-  ? path.join(process.cwd(), moduleRoot)
-  : undefined;
-
-if (moduleRootAbsolute && !fs.existsSync(moduleRootAbsolute)) {
-  throw new Error(
-    'Directory "' +
-      moduleRootAbsolute +
-      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript',
-  );
-}
-
 const importRegEx =
   /import\(["']([^"']*)["']\)(?:\.([^ \.\|\}><,\)=#\n]*))?([ \.\|\}><,\)=#\n])/g;
 const typedefRegEx = /@typedef \{[^\}]*\} (\S+)/g;
@@ -25,13 +11,11 @@ const noClassdescRegEx = /@(typedef|module|type)/;
 const extensionReplaceRegEx = /\.m?js$/;
 const extensionEnsureRegEx = /(\.js)?$/;
 const slashRegEx = /\\/g;
-const leadingPathSegmentRegEx = /^(.?.[/\\])+/;
 
 const moduleInfos = {};
 const fileNodes = {};
 const resolvedPathCache = new Set();
 
-// Without explicit module ids, JSDoc will use the nearest shared parent directory
 /** @type {string} */
 let implicitModuleRoot;
 
@@ -74,14 +58,6 @@ function getImplicitModuleRoot() {
 function getModuleId(modulePath) {
   if (moduleInfos[modulePath]) {
     return moduleInfos[modulePath].id;
-  }
-
-  // Use moduleRoot if set
-  if (moduleRootAbsolute) {
-    return path
-      .relative(moduleRootAbsolute, modulePath)
-      .replace(extensionReplaceRegEx, '')
-      .replace(leadingPathSegmentRegEx, '');
   }
 
   // Search for explicit module id

--- a/index.js
+++ b/index.js
@@ -30,14 +30,15 @@ const leadingPathSegmentRegEx = /^(.?.[/\\])+/;
 const moduleInfos = {};
 const fileNodes = {};
 
-let inferredModuleRoot;
+// Without explicit module ids, JSDoc will use the nearest shared ancestor directory
+let implicitModuleRoot;
 
-function getInferredModuleRoot() {
-  if (inferredModuleRoot) {
-    return inferredModuleRoot;
+function getImplicitModuleRoot() {
+  if (implicitModuleRoot) {
+    return implicitModuleRoot;
   }
 
-  inferredModuleRoot = env.sourceFiles.reduce((nearestAncestor, curr, i) => {
+  implicitModuleRoot = env.sourceFiles.reduce((nearestAncestor, curr, i) => {
     if (curr.startsWith(nearestAncestor) || i === 0) {
       return nearestAncestor;
     }
@@ -52,7 +53,7 @@ function getInferredModuleRoot() {
     }
   }, path.dirname(env.sourceFiles[0]));
 
-  return inferredModuleRoot;
+  return implicitModuleRoot;
 }
 
 function getModuleInfo(modulePath, parser) {
@@ -134,9 +135,9 @@ function getModuleId(modulePath) {
     }
   }
 
-  if (getInferredModuleRoot()) {
+  if (getImplicitModuleRoot()) {
     return path
-      .relative(inferredModuleRoot, modulePath)
+      .relative(implicitModuleRoot, modulePath)
       .replace(extensionReplaceRegEx, '');
   }
 

--- a/index.js
+++ b/index.js
@@ -35,17 +35,25 @@ const fileNodes = {};
 let implicitModuleRoot;
 
 /**
- * @return {string} The nearest shared parent directory of all source files.
+ * Without explicit module ids, JSDoc will use `process.cwd()` if all source files are within cwd.
+ * If any source files are outside cwd, JSDoc will use the nearest shared parent directory.
+ * @return {string} The implicit root path with which to resolve all module ids against.
  */
 function getImplicitModuleRoot() {
   if (implicitModuleRoot) {
     return implicitModuleRoot;
   }
 
-  if (!env.sourceFiles || env.sourceFiles.length === 0) {
+  if (
+    !env.sourceFiles ||
+    env.sourceFiles.length === 0 ||
+    // If all files are in cwd
+    env.sourceFiles.every((f) => f.startsWith(process.cwd()))
+  ) {
     return process.cwd();
   }
 
+  // Find the nearest shared parent directory
   implicitModuleRoot = path.dirname(env.sourceFiles[0]);
 
   env.sourceFiles.slice(1).forEach((filePath) => {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ if (moduleRootAbsolute && !fs.existsSync(moduleRootAbsolute)) {
   throw new Error(
     'Directory "' +
       moduleRootAbsolute +
-      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript'
+      '" does not exist. Check the "typescript.moduleRoot" config option for jsdoc-plugin-typescript',
   );
 }
 
@@ -236,7 +236,7 @@ exports.defineTags = function (dictionary) {
         }
         throw new Error("Missing closing '}'");
       };
-    }
+    },
   );
 };
 
@@ -327,10 +327,10 @@ exports.astNodeVisitor = {
             if (
               leadingComments.length === 0 ||
               (leadingComments[leadingComments.length - 1].value.indexOf(
-                '@classdesc'
+                '@classdesc',
               ) === -1 &&
                 noClassdescRegEx.test(
-                  leadingComments[leadingComments.length - 1].value
+                  leadingComments[leadingComments.length - 1].value,
                 ))
             ) {
               // Create a suitable comment node if we don't have one on the class yet
@@ -348,7 +348,7 @@ exports.astNodeVisitor = {
             if (node.superClass) {
               // Remove the `@extends` tag because JSDoc does not does not handle generic type. (`@extends {Base<Type>}`)
               const extendsIndex = lines.findIndex((line) =>
-                line.includes('@extends')
+                line.includes('@extends'),
               );
               if (extendsIndex !== -1) {
                 lines.splice(extendsIndex, 1);
@@ -360,7 +360,7 @@ exports.astNodeVisitor = {
               if (identifier) {
                 const absolutePath = getResolvedPath(
                   path.dirname(currentSourceName),
-                  ensureJsExt(identifier.value)
+                  ensureJsExt(identifier.value),
                 );
                 const moduleInfo = getModuleInfo(absolutePath, parser);
 
@@ -392,7 +392,7 @@ exports.astNodeVisitor = {
           // Replace typeof Foo with Class<Foo>
           comment.value = comment.value.replace(
             /typeof ([^,\|\}\>]*)([,\|\}\>])/g,
-            'Class<$1>$2'
+            'Class<$1>$2',
           );
 
           // Remove `@override` annotations to avoid JSDoc breaking the inheritance chain
@@ -420,7 +420,7 @@ exports.astNodeVisitor = {
                 if (replaceAttempt > 100) {
                   // infinite loop protection
                   throw new Error(
-                    `Invalid docstring ${comment.value} in ${currentSourceName}.`
+                    `Invalid docstring ${comment.value} in ${currentSourceName}.`,
                   );
                 }
               } else {
@@ -430,7 +430,7 @@ exports.astNodeVisitor = {
 
               const rel = getResolvedPath(
                 path.dirname(currentSourceName),
-                ensureJsExt(importSource)
+                ensureJsExt(importSource),
               );
               const moduleInfo = getModuleInfo(rel, parser);
 
@@ -445,14 +445,14 @@ exports.astNodeVisitor = {
 
                 replacement = `module:${moduleInfo.id.replace(
                   slashRegEx,
-                  '/'
+                  '/',
                 )}${name ? delimiter + name : ''}`;
               }
             }
             if (replacement) {
               comment.value = comment.value.replace(
                 importExpression,
-                replacement + remainder
+                replacement + remainder,
               );
             }
           }
@@ -473,13 +473,13 @@ exports.astNodeVisitor = {
           Object.keys(identifiers).forEach((key) => {
             const eventRegex = new RegExp(
               `@(event |fires )${key}([^A-Za-z])`,
-              'g'
+              'g',
             );
             replace(eventRegex);
 
             const typeRegex = new RegExp(
               `@(.*[{<|,(!?:]\\s*)${key}([^A-Za-z].*?\}|\})`,
-              'g'
+              'g',
             );
             replace(typeRegex);
 
@@ -488,7 +488,7 @@ exports.astNodeVisitor = {
                 const identifier = identifiers[key];
                 const absolutePath = getResolvedPath(
                   path.dirname(currentSourceName),
-                  ensureJsExt(identifier.value)
+                  ensureJsExt(identifier.value),
                 );
                 const moduleInfo = getModuleInfo(absolutePath, parser);
 
@@ -503,12 +503,12 @@ exports.astNodeVisitor = {
 
                   const replacement = `module:${moduleInfo.id.replace(
                     slashRegEx,
-                    '/'
+                    '/',
                   )}${exportName ? delimiter + exportName : ''}`;
 
                   comment.value = comment.value.replace(
                     regex,
-                    '@$1' + replacement + '$2'
+                    '@$1' + replacement + '$2',
                   );
                 }
               }

--- a/index.js
+++ b/index.js
@@ -30,10 +30,13 @@ const leadingPathSegmentRegEx = /^(.?.[/\\])+/;
 const moduleInfos = {};
 const fileNodes = {};
 
-// Without explicit module ids, JSDoc will use the nearest shared ancestor directory
+// Without explicit module ids, JSDoc will use the nearest shared parent directory
 /** @type {string} */
 let implicitModuleRoot;
 
+/**
+ * @return {string} The nearest shared parent directory of all source files.
+ */
 function getImplicitModuleRoot() {
   if (implicitModuleRoot) {
     return implicitModuleRoot;
@@ -43,11 +46,11 @@ function getImplicitModuleRoot() {
     return process.cwd();
   }
 
-  implicitModuleRoot = env.sourceFiles[0];
+  implicitModuleRoot = path.dirname(env.sourceFiles[0]);
 
   env.sourceFiles.slice(1).forEach((filePath) => {
     if (filePath.startsWith(implicitModuleRoot)) {
-      return implicitModuleRoot;
+      return;
     }
 
     const currParts = filePath.split(path.sep);
@@ -55,7 +58,9 @@ function getImplicitModuleRoot() {
 
     for (let i = 0; i < currParts.length; ++i) {
       if (currParts[i] !== nearestParts[i]) {
-        return currParts.slice(0, i).join(path.sep);
+        implicitModuleRoot = currParts.slice(0, i).join(path.sep);
+
+        return;
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -35,8 +35,7 @@ const fileNodes = {};
 let implicitModuleRoot;
 
 /**
- * Without explicit module ids, JSDoc will use `process.cwd()` if all source files are within cwd.
- * If any source files are outside cwd, JSDoc will use the nearest shared parent directory.
+ * Without explicit module ids, JSDoc will use the nearest shared parent directory.
  * @return {string} The implicit root path with which to resolve all module ids against.
  */
 function getImplicitModuleRoot() {
@@ -44,12 +43,7 @@ function getImplicitModuleRoot() {
     return implicitModuleRoot;
   }
 
-  if (
-    !env.sourceFiles ||
-    env.sourceFiles.length === 0 ||
-    // If all files are in cwd
-    env.sourceFiles.every((f) => f.startsWith(process.cwd()))
-  ) {
+  if (!env.sourceFiles || env.sourceFiles.length === 0) {
     return process.cwd();
   }
 

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -144,7 +144,7 @@
     "params": []
   },
   {
-    "comment": "/**\n * @param {number} number A number.\n * @return {module:sub/NumberStore~NumberStore} A number store.\n */",
+    "comment": "/**\n * @param {number} number A number.\n * @return {module:test/sub/NumberStore~NumberStore} A number store.\n */",
     "meta": {
       "range": [
         495,
@@ -176,7 +176,7 @@
       {
         "type": {
           "names": [
-            "module:sub/NumberStore~NumberStore"
+            "module:test/sub/NumberStore~NumberStore"
           ]
         },
         "description": "A number store."
@@ -306,7 +306,7 @@
     "undocumented": true
   },
   {
-    "comment": "/**\n   * @param {module:sub/NumberStore~Options} options The options.\n   */",
+    "comment": "/**\n   * @param {module:test/sub/NumberStore~Options} options The options.\n   */",
     "meta": {
       "range": [
         231,
@@ -330,7 +330,7 @@
       {
         "type": {
           "names": [
-            "module:sub/NumberStore~Options"
+            "module:test/sub/NumberStore~Options"
           ]
         },
         "description": "The options.",
@@ -372,7 +372,7 @@
       {
         "type": {
           "names": [
-            "module:sub/NumberStore~Options"
+            "module:test/sub/NumberStore~Options"
           ]
         },
         "description": "The options.",

--- a/test/template/config.json
+++ b/test/template/config.json
@@ -5,17 +5,10 @@
     "destination": "test/dest/actual.json"
   },
   "source": {
-    "include": [
-      "test/src"
-    ]
+    "include": ["test/src"]
   },
   "tags": {
     "allowUnknownTags": true
   },
-  "plugins": [
-    "index.js"
-  ],
-  "typescript": {
-    "moduleRoot": "test/src"
-  }
+  "plugins": ["index.js"]
 }


### PR DESCRIPTION
This PR adds support for resolving module paths using explicit module ids (`@module <id>`) and implicit module ids, mirroring the same method JSDoc uses. The `typescript.moduleRoot` config option is still prioritised over these for backwards compact. 

This PR also:

- Removes leading `../` path segments from module ids (if a referenced module is located outside the cwd), as they cause errors.
- Resolves `/index.js` for paths that target the parent directory.

## Changes

- Update README
- No longer throw errors for missing `typescript.moduleRoot` config option, only if present and the provided path doesn't exist
- Use absolute file paths as keys in `moduleInfos` and `fileNodes` instead of module ids to simplify setting and accessing
- `getImplicitRoot` function for when there's no `typescript.moduleRoot` option or explicit module id
- `getModuleId` function
- Cache module ids in `moduleInfos`
- Remove `parser` param from `getDefaultExportName` and `getDelimiter` as it's being passed to the `extension` param of `getModuleInfo`

## Additional notes

In my opinion, the `typescript.moduleRoot` config option should be deprecated, as it introduces the risk of a mismatch between what JSDoc considers an existing module id and the id this plugin uses internally.

I was unsure how to add tests for this - open to any suggestions.