### PR TITLE
Fix typedef regex to allow typedefs without contraints

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ if (!fs.existsSync(moduleRootAbsolute)) {
 
 const importRegEx =
   /import\(["']([^"']*)["']\)(?:\.([^ \.\|\}><,\)=#\n]*))?([ \.\|\}><,\)=#\n])/g;
-const typedefRegEx = /@typedef \{[^\}]*\} (\S+)/g;
+const typedefRegEx = /@typedef\s*(?:\{[^\}]*\}\s*)?([^\{\}\s]+)/g;
 const noClassdescRegEx = /@(typedef|module|type)/;
 const extensionReplaceRegEx = /\.m?js$/;
 const slashRegEx = /\\/g;


### PR DESCRIPTION
`typedef` tags are valid without a type constraint, but `typedefRegEx` requires one. This PR updates the regex to allow optional constraints, as well as any length whitespace.