### PR TITLE
Link tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ When assigned to a variable in the exporting module:
 
 This syntax is also used when referring to types of `@typedef`s and `@enum`s.
 
+### `@link` tags
+
+```js
+/**
+ * {@link Identifier}
+ */
+
+/**
+ * {@link Identifier Link text}
+ */
+
+/**
+ * {@link Identifier.member}
+ */
+```
+
+To:
+
+```js
+/**
+ * {@link module:path/to/module.Identifier Identifier}
+ */
+
+/**
+ * {@link module:path/to/module.Identifier Link text}
+ */
+
+/**
+ * Member accessors are not currently linked to, just the root identifier:
+ * {@link module:path/to/module.Identifier Identifier.member}
+ */
+```
+
 ### `typeof type`
 
 ```js
@@ -165,6 +198,7 @@ To:
 ```
 
 To:
+
 ```js
 /**
  * @type {Array}

--- a/index.js
+++ b/index.js
@@ -593,11 +593,15 @@ exports.astNodeVisitor = {
             replace(typeRegex);
 
             const linkWithoutTextRegex = new RegExp(
-              `@(link (?!https?))${key}((?:\\.[^\\s\\}]*)*\\s*\\})`,
+              `@(link (?!https?:))${key}((?:\\.[^\\s}]*)*\\s*\\})`,
+              'g',
+            );
+            const linkMemberAccessorRegex = new RegExp(
+              `@(link (?!https?:)${key})(?:\\.[^\\s}]*)*([\\s|][^}]*\\})`,
               'g',
             );
             const linkWithTextRegex = new RegExp(
-              `@(link (?!https?))${key}((?:\\.[^\\s\\}]*)*(?:\\s|\\s*\\|)[^\\}]*\\})`,
+              `@(link (?!https?:))${key}([\\s|][^}]*\\})`,
               'g',
             );
 
@@ -605,6 +609,11 @@ exports.astNodeVisitor = {
             comment.value = comment.value.replace(
               linkWithoutTextRegex,
               `@$1${key} ${key}$2`,
+            );
+            // Remove member accessors from link key
+            comment.value = comment.value.replace(
+              linkMemberAccessorRegex,
+              '@$1$2',
             );
 
             replace(linkWithTextRegex);

--- a/index.js
+++ b/index.js
@@ -592,6 +592,23 @@ exports.astNodeVisitor = {
             );
             replace(typeRegex);
 
+            const linkWithoutTextRegex = new RegExp(
+              `@(link (?!https?))${key}(\\.[^\\s\\}]*)*(\\s*\\})`,
+              'g',
+            );
+            const linkWithTextRegex = new RegExp(
+              `@(link (?!https?))${key}((?:\\.[^\\s\\}]*)*(?:\\s|\\s*\\|)[^\\}]*\\})`,
+              'g',
+            );
+
+            // If link is without text, use key as text
+            comment.value = comment.value.replace(
+              linkWithoutTextRegex,
+              `@$1${key} ${key}$2$3`,
+            );
+
+            replace(linkWithTextRegex);
+
             function replace(regex) {
               if (regex.test(comment.value)) {
                 const identifier = identifiers[key];

--- a/index.js
+++ b/index.js
@@ -593,7 +593,7 @@ exports.astNodeVisitor = {
             replace(typeRegex);
 
             const linkWithoutTextRegex = new RegExp(
-              `@(link (?!https?))${key}(\\.[^\\s\\}]*)*(\\s*\\})`,
+              `@(link (?!https?))${key}((?:\\.[^\\s\\}]*)*\\s*\\})`,
               'g',
             );
             const linkWithTextRegex = new RegExp(
@@ -604,7 +604,7 @@ exports.astNodeVisitor = {
             // If link is without text, use key as text
             comment.value = comment.value.replace(
               linkWithoutTextRegex,
-              `@$1${key} ${key}$2$3`,
+              `@$1${key} ${key}$2`,
             );
 
             replace(linkWithTextRegex);

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -742,6 +742,98 @@
     "params": []
   },
   {
+    "comment": "/**\n * {@link module:test/sub/NumberStore~NumberStore NumberStore}\n */",
+    "meta": {
+      "range": [
+        1424,
+        1456
+      ],
+      "filename": "index.js",
+      "lineno": 67,
+      "columnno": 0,
+      "code": {
+        "name": "exports.Link",
+        "type": "VariableDeclaration"
+      }
+    },
+    "description": "{@link module:test/sub/NumberStore~NumberStore NumberStore}",
+    "name": "Link",
+    "longname": "module:test.Link",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        1437,
+        1455
+      ],
+      "filename": "index.js",
+      "lineno": 67,
+      "columnno": 13,
+      "code": {
+        "name": "Link",
+        "type": "Identifier",
+        "value": "NumberStore"
+      }
+    },
+    "undocumented": true,
+    "name": "Link",
+    "longname": "module:test~Link",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "/**\n * {@link module:test/sub/NumberStore~NumberStore Num}\n */",
+    "meta": {
+      "range": [
+        1493,
+        1533
+      ],
+      "filename": "index.js",
+      "lineno": 72,
+      "columnno": 0,
+      "code": {
+        "name": "exports.LinkWithText",
+        "type": "VariableDeclaration"
+      }
+    },
+    "description": "{@link module:test/sub/NumberStore~NumberStore Num}",
+    "name": "LinkWithText",
+    "longname": "module:test.LinkWithText",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        1506,
+        1532
+      ],
+      "filename": "index.js",
+      "lineno": 72,
+      "columnno": 13,
+      "code": {
+        "name": "LinkWithText",
+        "type": "Identifier",
+        "value": "NumberStore"
+      }
+    },
+    "undocumented": true,
+    "name": "LinkWithText",
+    "longname": "module:test~LinkWithText",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
     "comment": "/** @ignore */",
     "meta": {
       "range": [

--- a/test/dest/expected.json
+++ b/test/dest/expected.json
@@ -834,6 +834,98 @@
     "params": []
   },
   {
+    "comment": "/**\n * {@link module:test/sub/NumberStore~NumberStore NumberStore.getNumber}\n */",
+    "meta": {
+      "range": [
+        1576,
+        1626
+      ],
+      "filename": "index.js",
+      "lineno": 77,
+      "columnno": 0,
+      "code": {
+        "name": "exports.LinkWithMemberAccessor",
+        "type": "VariableDeclaration"
+      }
+    },
+    "description": "{@link module:test/sub/NumberStore~NumberStore NumberStore.getNumber}",
+    "name": "LinkWithMemberAccessor",
+    "longname": "module:test.LinkWithMemberAccessor",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        1589,
+        1625
+      ],
+      "filename": "index.js",
+      "lineno": 77,
+      "columnno": 13,
+      "code": {
+        "name": "LinkWithMemberAccessor",
+        "type": "Identifier",
+        "value": "NumberStore"
+      }
+    },
+    "undocumented": true,
+    "name": "LinkWithMemberAccessor",
+    "longname": "module:test~LinkWithMemberAccessor",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
+    "comment": "/**\n * {@link module:test/sub/NumberStore~NumberStore Num}\n */",
+    "meta": {
+      "range": [
+        1673,
+        1730
+      ],
+      "filename": "index.js",
+      "lineno": 82,
+      "columnno": 0,
+      "code": {
+        "name": "exports.LinkWithMemberAccessorAndText",
+        "type": "VariableDeclaration"
+      }
+    },
+    "description": "{@link module:test/sub/NumberStore~NumberStore Num}",
+    "name": "LinkWithMemberAccessorAndText",
+    "longname": "module:test.LinkWithMemberAccessorAndText",
+    "kind": "constant",
+    "memberof": "module:test",
+    "scope": "static"
+  },
+  {
+    "comment": "",
+    "meta": {
+      "range": [
+        1686,
+        1729
+      ],
+      "filename": "index.js",
+      "lineno": 82,
+      "columnno": 13,
+      "code": {
+        "name": "LinkWithMemberAccessorAndText",
+        "type": "Identifier",
+        "value": "NumberStore"
+      }
+    },
+    "undocumented": true,
+    "name": "LinkWithMemberAccessorAndText",
+    "longname": "module:test~LinkWithMemberAccessorAndText",
+    "kind": "constant",
+    "scope": "inner",
+    "memberof": "module:test",
+    "params": []
+  },
+  {
     "comment": "/** @ignore */",
     "meta": {
       "range": [

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -60,3 +60,13 @@ export const bracketNotation = 1;
 
 /** @type {[number, [number, string], "[number, boolean]"]} */
 export const nesteedTuples = [1, [1, 'a'], '[number, boolean]'];
+
+/**
+ * {@link NumberStore}
+ */
+export const Link = NumberStore;
+
+/**
+ * {@link NumberStore Num}
+ */
+export const LinkWithText = NumberStore;

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -70,3 +70,13 @@ export const Link = NumberStore;
  * {@link NumberStore Num}
  */
 export const LinkWithText = NumberStore;
+
+/**
+ * {@link NumberStore.getNumber}
+ */
+export const LinkWithMemberAccessor = NumberStore;
+
+/**
+ * {@link NumberStore.getNumber Num}
+ */
+export const LinkWithMemberAccessorAndText = NumberStore;


### PR DESCRIPTION
This PR adds support for `@link` tag parsing, converting identifiers to their full module paths. It respects link text if it exists, if not, it uses the original identifier.

For nested member access, it just links to the root identifier, because finding what kind of member it is and constructing the namepath correctly is a bit more complicated and I don't fully understand how it works.

---

**Some further notes on nested member access that could be added in a separate issue:**

We'd need to know what kind of member it is - instance or static, property or method - and format the namepath accordingly.

To find out what kind of member it is, we could use the AST cached in `fileNodes`, though, that could cause an issue if the imported file hasn't been cached yet.

Using the default JSDoc template, I found links work with the `Identifier#member` namepath format for everything except static methods which require `Identifier.member`:

- `module:path/to/module.Identifier#member`
    - Instance properties
    - Instance methods
    - Getters/setters
    - Static properties
- `module:path/to/module.Identifier.member`
    - Static methods

[`Identifier#member` working for static properties contradicts the docs, which says `Identifier.member` should be used for static members](https://jsdoc.app/about-namepaths). This could be a bug in JSDoc core, a bug in the default template, or just incorrect documentation, I don't know.
