### PR TITLE
Fix type replace regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -587,7 +587,7 @@ exports.astNodeVisitor = {
             replace(eventRegex);
 
             const typeRegex = new RegExp(
-              `@(.*[{<|,(!?:]\\s*)${key}([^A-Za-z].*?\}|\})`,
+              `@(.*[{<|,(!?:]\\s*)(?<!https?:|module:|event:|external:)${key}([^A-Za-z].*?\}|\})`,
               'g',
             );
             replace(typeRegex);

--- a/index.js
+++ b/index.js
@@ -587,7 +587,7 @@ exports.astNodeVisitor = {
             replace(eventRegex);
 
             const typeRegex = new RegExp(
-              `@(.*[{<|,(!?:]\\s*)(?<!https?:|module:|event:|external:)${key}([^A-Za-z].*?\}|\})`,
+              `@(.*[{<|,(!?:]\\s*)(?<!module:|event:|external:)${key}([^A-Za-z].*?\}|\})`,
               'g',
             );
             replace(typeRegex);


### PR DESCRIPTION
If a key in `identifiers` matches the name of a `module:`, `event:`, or `external:` namepath, it'll end up being prefixed with `module:`.

So `@returns {module:geometry}` becomes `@returns {module:module:geometry}`, if a `geometry` identifier exists elsewhere.

This PR updates the regex to exclude these cases.